### PR TITLE
fix: remove black border that appeared on captcha image

### DIFF
--- a/src/Captcha.Core/Models/CaptchaImage.cs
+++ b/src/Captcha.Core/Models/CaptchaImage.cs
@@ -99,6 +99,6 @@ public class CaptchaImage(CaptchaConfigurationData config)
     private static void FillInTheBackground(Rectangle rectangle, Graphics graphics)
     {
         using var hatchBrush = new HatchBrush(HatchStyle.SmallConfetti, Color.LightGray, Color.White);
-        graphics.FillRectangle(hatchBrush, rectangle);
+        graphics.FillRegion(hatchBrush, new Region(rectangle));
     }
 }

--- a/tests/Captcha.FunctionalTests/Features/Captcha.feature
+++ b/tests/Captcha.FunctionalTests/Features/Captcha.feature
@@ -31,3 +31,13 @@ I want to send different captcha requests and assure the image is generated
           | Ciao         | 200   |        | Easy        | 200           | 100            |
           | Olá          | 300   | 300    | Challenging | 300           | 300            |
           | สวัสดี         | 400   | 400    | Hard        | 400           | 400            |
+
+    Scenario: Captcha should not have any black borders
+        Given I have a captcha request with following parameters:
+          | Text    | Width | Height | Difficulty |
+          | Bonjour |       |        | Easy       |
+        When I send the request to the Create endpoint of the CaptchaController
+        Then I expect a captcha image to be returned with the following attributes:
+          | Width | Height |
+          | 400   | 100    |
+        Then I expect a captcha image to be returned without any black borders

--- a/tests/Captcha.FunctionalTests/StepDefinitions/CaptchaSteps.cs
+++ b/tests/Captcha.FunctionalTests/StepDefinitions/CaptchaSteps.cs
@@ -51,4 +51,26 @@ public class CaptchaSteps(ScenarioContext context) : TestBase(context)
         Assert.That(img.Width, Is.EqualTo(expectedWidth));
         Assert.That(img.Height, Is.EqualTo(expectedHeight));
     }
+
+    [Then(@"I expect a captcha image to be returned without any black borders")]
+    public void ThenIExpectACaptchaImageToBeReturnedWithoutAnyBlackBorders()
+    {
+        using var ms = new MemoryStream(_response.RawBytes);
+        var img = Image.FromStream(ms);
+        var bmp = new Bitmap(img);
+
+        for (var i = 0; i < bmp.Width; i++)
+        {
+            for (var j = 0; j < bmp.Height; j++)
+            {
+                var pixel = bmp.GetPixel(i, j);
+
+                // If either R or G or B is less than 100, then it's a dark color
+                if (pixel.R < 100 || pixel.G < 100 || pixel.B < 100)
+                {
+                    throw new AssertionException($"Black/Dark color found in the image. Hex: {pixel.Name}");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This change removes the black border that appeared on the captcha image.

before:
![image2](https://github.com/user-attachments/assets/d898f7db-6abb-4024-9f11-0fba86ee5abe)


after:
![image](https://github.com/user-attachments/assets/3009c9f4-3acb-44f8-8a77-4d1aadd61184)


